### PR TITLE
Import benchmark in cluster_test under the testing context

### DIFF
--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -24,6 +24,7 @@ config_builder = { path = "../config/config_builder" }
 failure = { package = "failure_ext", path = "../common/failure_ext" }
 generate_keypair = { path = "../config/generate_keypair" }
 libra_wallet = { path = "../client/libra_wallet" }
+libra_swarm = { path = "../libra_swarm"}
 logger = { path = "../common/logger" }
 metrics = { path = "../common/metrics" }
 crypto = { path = "../crypto/crypto" }
@@ -35,3 +36,7 @@ vm_genesis = { path = "../language/vm/vm_genesis" }
 [dev-dependencies]
 crypto = { path = "../crypto/crypto", features = ["testing"] }
 libra_swarm = { path = "../libra_swarm", features = ["testing"]}
+
+[features]
+default = []
+testing = ["crypto/testing", "libra_swarm/testing"]

--- a/testsuite/cluster_test/Cargo.toml
+++ b/testsuite/cluster_test/Cargo.toml
@@ -21,5 +21,5 @@ clap = "2.32"
 termion = "1.5.3"
 itertools = "0.8.0"
 reqwest = "0.9.19"
-benchmark = { path = "../../benchmark"}
+benchmark = { path = "../../benchmark", features = ["testing"]}
 openssl = { version = "0.10", features = ["vendored"] }


### PR DESCRIPTION
This allows the benchmark crate to propagate the testing context it receives from cluster_test (a testsuite, test-only rate) to libra_swarm.
